### PR TITLE
#25: Adds the original message of the user with response

### DIFF
--- a/apps/telegram-bot/src/functions.rs
+++ b/apps/telegram-bot/src/functions.rs
@@ -162,7 +162,15 @@ pub async fn process_music_share(
             .mention()
             .unwrap_or_else(|| user_mention(user.id, user.full_name().as_str()));
         tracing::debug!("Adding attribution for user: {}", user.full_name());
-        response.push_str(&format!("\n\nPosted by {}", username));
+        let cleaned_text = get_regex_for_url()
+            .replace_all(text.trim(), "[OG LINK]")
+            .into_owned();
+        if !cleaned_text.trim().is_empty() {
+            response.push_str(&format!("\n\nPosted by {}: {}", username, cleaned_text.trim()));
+        } else {
+            tracing::debug!("Only URL contained in the user message")
+            response.push_str(&format!("\n\nPosted by {}", username));
+        }
     }
 
     tracing::debug!("Returning response with {} characters", response.len());


### PR DESCRIPTION
The original user message is added to the attributions in the response sent by the bot. The original message is kept as is only replacing the `<URL>` with `[OG LINK]`